### PR TITLE
Connection indicator

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -133,9 +133,8 @@ export class LinkEncoderAPI {
                 resolve(this.socket);
                 console.log('Connected to ' + host + ':' + port);
             });
-            this.socket.on('error', () => {
+            this.socket.on('error', (error) => {
                 this.socket = null;
-                console.log('Error: Trying to connect to a closed server or server unexpectedly shut down');
             });
         });
     }
@@ -185,7 +184,6 @@ export class LinkEncoderAPI {
             console.log('Attempting connection');
             await this.connecttoserver(port, host);
             
-            //console.log('Connected to ' + host + ':' + port);
         }
         else {
             this.socket.destroy();

--- a/src/api.js
+++ b/src/api.js
@@ -134,6 +134,9 @@ export class LinkEncoderAPI {
                 console.log('Connected to ' + host + ':' + port);
             });
             this.socket.on('error', () => {
+                //this.socket.destroy();
+                this.newswire = null;
+                this.fieldinsertmode = null;
                 this.socket = null;
             });
         });

--- a/src/api.js
+++ b/src/api.js
@@ -133,7 +133,7 @@ export class LinkEncoderAPI {
                 resolve(this.socket);
                 console.log('Connected to ' + host + ':' + port);
             });
-            this.socket.on('error', (error) => {
+            this.socket.on('error', () => {
                 this.socket = null;
             });
         });

--- a/src/components/LinkEncoder/Network.jsx
+++ b/src/components/LinkEncoder/Network.jsx
@@ -18,7 +18,7 @@ import LensIcon from '@mui/icons-material/Lens';
  *   Need to change to a better alignment
  */
 
-let interval; //for 5s ping
+let interval, errorInterval; //for 5s ping
 const Network = (props) => {
   
   const [connectButtonText, setConnectButtonText] = useState('Connect');
@@ -28,7 +28,26 @@ const Network = (props) => {
   const [indicatorTextColor, setIndicatorTextColor] = useState("red");
   const [indicatorText, setIndicatorText] = useState('Disconnected');
   
+
+  const checkingConnection = async () => {
+    return new Promise(resolve => {
+        errorInterval = setInterval(async () => {
+            const retCode = await window.linkEncoderAPI.checkLinkEncoder();
+            if (retCode == 300) {
+                setDisplay(true);
+                setConnectButtonText('Connect');
+                setIndicatorColor("error");
+                setIndicatorTextColor("red");
+                setIndicatorText('Disconnected');
+            }    
+        }, 500);
+            
+        resolve();
+    })
+  };
+
   const connectAndDisconnect = async () => {
+    clearInterval(errorInterval);
     await window.linkEncoderAPI.connectionLinkEncoder(props.postData.ip, props.postData.port);
     const retCode = await window.linkEncoderAPI.checkLinkEncoder();
     if (retCode == 200) {
@@ -51,8 +70,8 @@ const Network = (props) => {
         setIndicatorColor("error");
         setIndicatorTextColor("red");
         setIndicatorText('Disconnected');
-
     }
+    await checkingConnection();
   };
 
   const pinging = async () => {
@@ -138,7 +157,11 @@ const Network = (props) => {
     </Box>
 
     <Stack direction="row" spacing={2} sx={{ m: 1 }} wrap="nowrap" alignItems="center" justifyContent="center">
-        <Button sx={{ background: '#13294B'}} variant="contained" className={`${props.classes.roundButton}`} onClick={connectAndDisconnect} id="rb">
+        <Button sx={{ background: '#13294B'}} variant="contained" className={`${props.classes.roundButton}`} 
+        onClick={() => {
+            connectAndDisconnect();
+            
+        }} id="rb">
             {connectButtonText}
         </Button>
 

--- a/src/components/LinkEncoder/Network.jsx
+++ b/src/components/LinkEncoder/Network.jsx
@@ -22,11 +22,12 @@ let interval; //for 5s ping
 const Network = (props) => {
   
   const [connectButtonText, setConnectButtonText] = useState('Connect');
-  const [indicatorColor, setIndicatorColor] = useState("success");
+  const [indicatorColor, setIndicatorColor] = useState("error");
   const [checked, setIsChecked] = useState(false);
   const [errorMessageDisplay, setDisplay] = useState(false);
   const [indicatorTextColor, setIndicatorTextColor] = useState("red");
-  const [indicatorText, setIndicatorText] = useState('Connected');
+  const [indicatorText, setIndicatorText] = useState('Disconnected');
+  
   const connectAndDisconnect = async () => {
     await window.linkEncoderAPI.connectionLinkEncoder(props.postData.ip, props.postData.port);
     const retCode = await window.linkEncoderAPI.checkLinkEncoder();
@@ -103,11 +104,11 @@ const Network = (props) => {
   }, [downloadLogUrl]);
 
   return <Box sx={{width:"220px", marginRight:"10px", padding:"20px", height:"100vh", backgroundClip:"border-box", backgroundColor:"#e8e9eb"}} >
-    <Stack direction="row" spacing={6} sx={{ m: 1, marginBottom: "20px" }} wrap="nowrap" alignItems="center">
+    <Stack direction="row" spacing={6} sx={{ m: 1, marginBottom: "20px"}} wrap="nowrap" alignItems="center" justifyContent="right">
         <Box>Network </Box>
-        <Stack direction="row" spacing={0.5} sx={{ m: 1, marginBottom: "20px" }} wrap="nowrap" alignItems="center">
-            <Box sx={{marginRight:"20px", width:"90%"}}fontSize={12} color={indicatorTextColor} > {indicatorText} </Box>
-            <LensIcon color={indicatorColor}></LensIcon>
+        <Stack direction="row" sx={{ m: 1, marginBottom: "20px" }} wrap="nowrap" alignItems="center">
+            <Box sx={{pr:"20px", maxWidth:"60%"}}fontSize={12} color={indicatorTextColor}> {indicatorText} </Box>
+            <LensIcon sx={{maxHeight:"18%", maxWidth:"18%", width:"18%", height:"18%"}} color={indicatorColor}></LensIcon>
         </Stack>
     </Stack>
 

--- a/src/components/LinkEncoder/Network.jsx
+++ b/src/components/LinkEncoder/Network.jsx
@@ -127,7 +127,7 @@ const Network = (props) => {
         <Box>Network </Box>
         <Stack direction="row" sx={{ m: 1, marginBottom: "20px" }} wrap="nowrap" alignItems="center">
             <Box sx={{pr:"20px", maxWidth:"60%"}}fontSize={12} color={indicatorTextColor}> {indicatorText} </Box>
-            <LensIcon sx={{maxHeight:"18%", maxWidth:"18%", width:"18%", height:"18%"}} color={indicatorColor}></LensIcon>
+            <LensIcon sx={{maxHeight:"15%", maxWidth:"15%", width:"12%", height:"12%", marginTop:"3px"}} color={indicatorColor}></LensIcon>
         </Stack>
     </Stack>
 

--- a/src/components/LinkEncoder/Network.jsx
+++ b/src/components/LinkEncoder/Network.jsx
@@ -9,6 +9,7 @@ import FormGroup from '@mui/material/FormLabel';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import { FormControl, FormLabel } from '@material-ui/core';
 import PropTypes from 'prop-types';
+import LensIcon from '@mui/icons-material/Lens';
 
 /**
  * 2022/04/27:
@@ -21,27 +22,35 @@ let interval; //for 5s ping
 const Network = (props) => {
   
   const [connectButtonText, setConnectButtonText] = useState('Connect');
-  const [selected, setSelected] = useState("success");
+  const [indicatorColor, setIndicatorColor] = useState("success");
   const [checked, setIsChecked] = useState(false);
   const [errorMessageDisplay, setDisplay] = useState(false);
-
+  const [indicatorTextColor, setIndicatorTextColor] = useState("red");
+  const [indicatorText, setIndicatorText] = useState('Connected');
   const connectAndDisconnect = async () => {
     await window.linkEncoderAPI.connectionLinkEncoder(props.postData.ip, props.postData.port);
     const retCode = await window.linkEncoderAPI.checkLinkEncoder();
     if (retCode == 200) {
         setDisplay(false);
         setConnectButtonText('Disconnect');
-        setSelected("error");
+        setIndicatorColor("success");
+        setIndicatorTextColor("green");
+        setIndicatorText('Connected');
     }
     else if (retCode == 300) {
         setDisplay(true);
         setConnectButtonText('Connect');
-        setSelected("success");
+        setIndicatorColor("error");
+        setIndicatorTextColor("red");
+        setIndicatorText('Disconnected');
     }
     else {
         setDisplay(false);
         setConnectButtonText('Connect');
-        setSelected("success");
+        setIndicatorColor("error");
+        setIndicatorTextColor("red");
+        setIndicatorText('Disconnected');
+
     }
   };
 
@@ -94,7 +103,15 @@ const Network = (props) => {
   }, [downloadLogUrl]);
 
   return <Box sx={{width:"220px", marginRight:"10px", padding:"20px", height:"100vh", backgroundClip:"border-box", backgroundColor:"#e8e9eb"}} >
-    <Box sx={{marginBottom:"20px"}}>Network</Box>
+    <Stack direction="row" spacing={6} sx={{ m: 1, marginBottom: "20px" }} wrap="nowrap" alignItems="center">
+        <Box>Network </Box>
+        <Stack direction="row" spacing={0.5} sx={{ m: 1, marginBottom: "20px" }} wrap="nowrap" alignItems="center">
+            <Box sx={{marginRight:"20px", width:"90%"}}fontSize={12} color={indicatorTextColor} > {indicatorText} </Box>
+            <LensIcon color={indicatorColor}></LensIcon>
+        </Stack>
+    </Stack>
+
+    
     <TextField
         name="ip"
         size='small'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/90006274/231340089-d37fc4f1-0f3c-4de7-b480-0453b1114750.png)
![image](https://user-images.githubusercontent.com/90006274/231340109-cf1c5f36-e068-4d75-ab7e-0c046aba5f3c.png)

when trying to connect to an closed server:
![image](https://user-images.githubusercontent.com/90006274/231340189-61294ab1-f20f-4027-8e97-ffed7753a3ef.png)

still haven't figured out how to automatically set the text to disconnected when the connection got interrupted. 